### PR TITLE
use git-filter-repo to cleanup old reports

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,29 @@
+name: "Cleanup old reports"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0' # Runs every Sunday at midnight
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: gh-pages
+
+      - name: Install and run git-filter-repo
+        run: |
+          apt-get install -y git-filter-repo
+          bash ./show-old-folders.sh > /tmp/remove-these.txt
+          git-filter-repo --paths-from-file=/tmp/remove-these.txt --invert-paths
+          git remote add origin git@github.com:rapidez/playwright-reports.git
+
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+            force_with_lease: true # Force push to overwrite history

--- a/show-old-folders.sh
+++ b/show-old-folders.sh
@@ -4,8 +4,8 @@
 git log --name-only --pretty=format: --diff-filter=A rapidez | awk '{print $1}' | sort | uniq | while read -r file; do
     folder=$(dirname "$file")
     last_commit_date=$(git log -1 --format="%ai" -- "$file")
-    last_commit_epoch=$(gdate -d "$last_commit_date" +%s)
-    one_month_ago=$(gdate -d "30 days ago" +%s)
+    last_commit_epoch=$(date -d "$last_commit_date" +%s)
+    one_month_ago=$(date -d "30 days ago" +%s)
     if [ "$last_commit_epoch" -lt "$one_month_ago" ]; then
         echo "$folder"
     fi

--- a/show-old-folders.sh
+++ b/show-old-folders.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Navigate to your repository
+# Find folders in "rapidez" that are older than a month
+git log --name-only --pretty=format: --diff-filter=A rapidez | awk '{print $1}' | sort | uniq | while read -r file; do
+    folder=$(dirname "$file")
+    last_commit_date=$(git log -1 --format="%ai" -- "$file")
+    last_commit_epoch=$(gdate -d "$last_commit_date" +%s)
+    one_month_ago=$(gdate -d "30 days ago" +%s)
+    if [ "$last_commit_epoch" -lt "$one_month_ago" ]; then
+        echo "$folder"
+    fi
+done


### PR DESCRIPTION
This PR runs every sunday to find folders that are older than 30 days.
Then runs [git-filter-repo](https://github.com/newren/git-filter-repo) in order to delete the files and folders, including from history since the Repo had already grown to 3GB in the last month.

git-filter-repo automatically expires the reflog and runs `git gc` so repo optimization is performed.
It will also remove commits that have no data anymore after the removal of those folders so the history will stay clean

Since the tool also removes the origin it is re-added.
Because the history has been rewritten we'll need to force-push